### PR TITLE
Fixing credential chain provider handling when key and secret are not supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Amazon SES Changelog
 
+## Unreleased
+### Fixed
+- Fixed support for proper default credential chain provider handling, when the key and secret aren't present.
+
 ## 1.1.0 - 2019-01-16
 ### Added
 - Added support for environmental settings introduced in Craft 3.1 ([#4](https://github.com/putyourlightson/craft-amazon-ses/issues/4)).


### PR DESCRIPTION
Little more was needed here to fix this issue: https://github.com/putyourlightson/craft-amazon-ses/issues/3

If no key or secret is supplied, the credentials array must be excluded. Then the credential chain provider will handle creds as needed. More here: https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html