### PR TITLE
Updated region list

### DIFF
--- a/src/mail/AmazonSesAdapter.php
+++ b/src/mail/AmazonSesAdapter.php
@@ -26,9 +26,13 @@ class AmazonSesAdapter extends BaseTransportAdapter
         'us-east-1',
         'us-west-2',
         'ap-south-1',
+        'ca-central-1',
         'ap-southeast-2',
         'eu-central-1',
         'eu-west-1',
+        'eu-west-2',
+        'sa-east-1',
+        'us-gov-west-1'
     ];
 
     // Static


### PR DESCRIPTION
Amazon introduced a couple of new API endpoints: 
https://docs.aws.amazon.com/general/latest/gr/ses.html


Region Name | Region | Endpoint | Protocol
-- | -- | -- | --
US East (N. Virginia) | us-east-1 | email.us-east-1.amazonaws.comemail-fips.us-east-1.amazonaws.com | HTTPS
US West (Oregon) | us-west-2 | email.us-west-2.amazonaws.comemail-fips.us-west-2.amazonaws.com | HTTPS
Asia Pacific (Mumbai) | ap-south-1 | email.ap-south-1.amazonaws.com | HTTPS
Asia Pacific (Sydney) | ap-southeast-2 | email.ap-southeast-2.amazonaws.com | HTTPS
Canada (Central) | ca-central-1 | email.ca-central-1.amazonaws.com | HTTPS
Europe (Frankfurt) | eu-central-1 | email.eu-central-1.amazonaws.com | HTTPS
Europe (Ireland) | eu-west-1 | email.eu-west-1.amazonaws.com | HTTPS
Europe (London) | eu-west-2 | email.eu-west-2.amazonaws.com | HTTPS
South America (São Paulo) | sa-east-1 | email.sa-east-1.amazonaws.com | HTTPS
AWS GovCloud (US) | us-gov-west-1 | email.us-gov-west-1.amazonaws.com | HTTPS

